### PR TITLE
Release/1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,8 +278,9 @@ $cache->set( 'test', 'Stored in memory!' );
 
 ### Void
 
-A cache adapter with very bad memory. Any items saved to this cache are silently
-discarded.
+A cache adapter with very bad memory.
+
+Any items saved to this cache are silently discarded.
 
 While this might sound useless, it can sometimes be helpful to test against an
 implementation that will always return **null** or to swap out the cache method

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -17,7 +17,7 @@ Interface CacheInterface
      * @param string $key Item key
      * @return mixed|null Item value (or null)
      */
-    public function get( string $key ) /* : ?mixed */;
+    public function get( string $key ) /* : mixed */;
 
     /**
      * Store an item in the cache

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -100,14 +100,14 @@ Class FileCache Implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function get( string $key ) /* : ?mixed */
+    public function get( string $key ) /* : mixed */
     {
         $root = $this->directory->getPath();
 
         $parts = $this->splitKey( $key );
 
         $filepath = implode( '/', $parts );
-        $filepath = "$root/$filepath.bin";
+        $filepath = "$root/$filepath.txt";
 
         $cache_file = new File( $filepath );
 
@@ -145,26 +145,28 @@ Class FileCache Implements CacheInterface
         $parts = $this->splitKey( $key );
         $filename = array_pop( $parts );
 
-        // Create sub-directories (if required)
+        // Sub-directory specified?
         if ( !empty( $parts ) ) {
-            $path = implode( '/', $parts );
-            $directory = $this->directory->create(
-                $path,
-                $this->permissions,
-                true
-            );
+            $cache_dir = implode( '/', $parts );
         } else {
-            $directory = $this->directory;
+            $cache_dir = '';
         }
 
+        // Move into (only creates if required)
+        $directory = $this->directory->create(
+            $cache_dir,
+            $this->permissions,
+            true
+        );
+
         // Failed to create directory
-        if ( $directory === null ) {
+        if ( $directory === null || !$directory->exists() ) {
             throw new CacheWriteException;
         }
 
         $root = $directory->getPath();
 
-        $cache_file = new File( "$root/$filename.bin" );
+        $cache_file = new File( "$root/$filename.txt" );
         $cache_file->write( $content );
 
         return;

--- a/src/MemcachedCache.php
+++ b/src/MemcachedCache.php
@@ -76,7 +76,7 @@ Class MemcachedCache Implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function get( string $key ) /* : ?mixed */
+    public function get( string $key ) /* : mixed */
     {
         /** @var mixed|false $result */
         $result = $this->memcached->get( $key );

--- a/src/SimpleCache.php
+++ b/src/SimpleCache.php
@@ -26,7 +26,7 @@ Class SimpleCache Implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function get( string $key ) /* : ?mixed */
+    public function get( string $key ) /* : mixed */
     {
         if ( isset( $this->items[$key] ) ) {
             if ( $this->items[$key]->isValid() ) {

--- a/src/VoidCache.php
+++ b/src/VoidCache.php
@@ -18,7 +18,7 @@ Class VoidCache Implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function get( string $key ) /* : ?mixed */
+    public function get( string $key ) /* : mixed */
     {
         return null;
     }


### PR DESCRIPTION
## Changed

- Cache files created by the `FileCache` now use the txt extension

## Fixed

- Resolved potential fatal error if the root cache directory did not exist
- Updated incorrect return type comments